### PR TITLE
adjust refresh endpoint

### DIFF
--- a/src/contexts/auth/application/ports/in/refresh-attempt.ts
+++ b/src/contexts/auth/application/ports/in/refresh-attempt.ts
@@ -1,5 +1,5 @@
 import { LoginResult } from '@/contexts/auth/entities/login-result';
 
 export interface RefreshAttempt {
-    execute(accessToken: string, refreshToken: string): Promise<LoginResult>;
+    execute(refreshToken: string): Promise<LoginResult>;
 }

--- a/src/contexts/auth/application/use-cases/refresh-attempt.test.ts
+++ b/src/contexts/auth/application/use-cases/refresh-attempt.test.ts
@@ -8,10 +8,7 @@ import { getAuthDescription } from '@/contexts/auth/application/services/get-aut
 import { AuthData } from '@/contexts/auth/entities/login-result';
 import { skipTime } from '@/shared/infra/testing/utils';
 import { expectResultOk } from '@/shared/infra/testing/assertions';
-import {
-    returnsExpiredAccessTokenWith,
-    returnsInvalidAccessTokenWith
-} from '@/contexts/auth/infra/testing/mock-token-verify';
+import { returnsExpiredAccessTokenWith } from '@/contexts/auth/infra/testing/mock-token-verify';
 import { UserRepo } from '@/contexts/auth/application/ports/out/user-repo';
 import { InMemoryUserRepo } from '@/contexts/auth/infra/in-memory-user-repo';
 
@@ -23,8 +20,6 @@ describe('RefreshAttemptUseCase', () => {
     let useCase: RefreshAttemptUseCase;
 
     const userId = 'someUserId';
-    const unusedAccessToken = 'validAccessToken';
-    const unusedRefreshToken = 'validRefreshToken';
 
     beforeEach(() => {
         refreshTokenRepo = new InMemoryRefreshTokenRepo();
@@ -34,33 +29,10 @@ describe('RefreshAttemptUseCase', () => {
         useCase = new RefreshAttemptUseCase(userRepo, refreshTokenService, authDescription);
     });
 
-    it('returns error if access token is malformed', async () => {
-        const result = await useCase.execute('malformed', unusedRefreshToken);
-
-        expect(result).toEqual({ ok: false, error: 'Malformed access token' });
-    });
-
-    it('returns error if userId is not in access token', async () => {
-        authDescription.verifyAccessToken = returnsInvalidAccessTokenWith('Invalid token');
-
-        const result = await useCase.execute(unusedAccessToken, unusedRefreshToken);
-
-        expect(result).toEqual({ ok: false, error: 'Malformed access token' });
-    });
-
-    it('returns error if refresh token is not owned by userId from access token', async () => {
-        authDescription.verifyAccessToken = returnsExpiredAccessTokenWith({ userId: 'susUser' });
-        const refreshToken = await refreshTokenService.issue(userId);
-
-        const result = await useCase.execute(unusedAccessToken, refreshToken);
-
-        expect(result).toEqual({ ok: false, error: 'Access token mismatch - invalid owner' });
-    });
-
     it('returns error if refresh token is invalid', async () => {
         authDescription.verifyAccessToken = returnsExpiredAccessTokenWith({ userId });
 
-        const result = await useCase.execute(unusedAccessToken, 'invalidRefresh');
+        const result = await useCase.execute('invalidRefresh');
 
         expect(result).toEqual({ ok: false, error: 'Invalid refresh token' });
     });
@@ -71,7 +43,7 @@ describe('RefreshAttemptUseCase', () => {
         const eightDaysMs = 8 * 24 * 60 * 60 * 1000;
         skipTime(eightDaysMs);
 
-        const result = await useCase.execute(unusedAccessToken, refreshToken);
+        const result = await useCase.execute(refreshToken);
 
         expect(result).toEqual({ ok: false, error: 'Refresh token expired' });
     });
@@ -80,7 +52,7 @@ describe('RefreshAttemptUseCase', () => {
         authDescription.verifyAccessToken = returnsExpiredAccessTokenWith({ userId });
         const refreshToken = await refreshTokenService.issue(userId);
 
-        const result = await useCase.execute(unusedAccessToken, refreshToken);
+        const result = await useCase.execute(refreshToken);
 
         expect(result).toEqual({ ok: false, error: 'Invalid user' });
     });
@@ -90,7 +62,7 @@ describe('RefreshAttemptUseCase', () => {
         await userRepo.upsert({ id: userId, passwordHash: 'unnecessary', email: 'doesnt@matter' });
         const refreshToken = await refreshTokenService.issue(userId);
 
-        const result = await useCase.execute(unusedAccessToken, refreshToken);
+        const result = await useCase.execute(refreshToken);
 
         expectResultOk<AuthData>(result);
         const atVerifyResult = await authDescription.verifyAccessToken(result.value.accessToken);
@@ -103,7 +75,7 @@ describe('RefreshAttemptUseCase', () => {
         authDescription.verifyAccessToken = returnsExpiredAccessTokenWith({ userId });
         const initialRt = await refreshTokenService.issue(userId);
 
-        await useCase.execute(unusedAccessToken, initialRt);
+        await useCase.execute(initialRt);
 
         const oldTokenFound = await refreshTokenService.find(initialRt);
         expect(oldTokenFound).toBeNull();

--- a/src/contexts/auth/interface/controllers/auth-controller.ts
+++ b/src/contexts/auth/interface/controllers/auth-controller.ts
@@ -30,8 +30,8 @@ export class AuthController {
         return this.loginAttempt.execute(email, password);
     }
 
-    onRefreshAttempt(accessToken: string, refreshToken: string): Promise<LoginResult> {
-        return this.refreshAttempt.execute(accessToken, refreshToken);
+    onRefreshAttempt(refreshToken: string): Promise<LoginResult> {
+        return this.refreshAttempt.execute(refreshToken);
     }
 
     async onLogout(accessToken: string, refreshToken: string): Promise<LogoutResult> {

--- a/src/contexts/auth/interface/web/auth-routes.ts
+++ b/src/contexts/auth/interface/web/auth-routes.ts
@@ -34,12 +34,11 @@ authRoutes.post('/logout', async (req, res) => {
 });
 
 authRoutes.get('/refresh', async (req, res) => {
-    const at = await getAuthDescription().extractAccessToken(req);
     const rt = await getAuthDescription().extractRefreshToken(req);
-    if (!at || !rt) {
-        throw new UnauthorizedError('Missing token. Please log in again.');
+    if (!rt) {
+        throw new UnauthorizedError('Missing refresh token. Please log in again.');
     }
-    const refreshResult = await authController.onRefreshAttempt(at, rt);
+    const refreshResult = await authController.onRefreshAttempt(rt);
     if (!refreshResult.ok) {
         throw new ValidationError(`Error during refresh: ${refreshResult.error}`);
     }

--- a/src/contexts/material/interface/controllers/material-controller.ts
+++ b/src/contexts/material/interface/controllers/material-controller.ts
@@ -15,8 +15,6 @@ import { LLMSummarizer } from '@/contexts/material/infra/summarizing/llm-summari
 import { OpenAIProvider } from '@/shared/infra/llms/open-ai-provider';
 import { ListValidUploadFiletypes } from '@/contexts/material/application/ports/in/list-valid-upload-filetypes';
 import { ListValidUploadFiletypesUseCase } from '@/contexts/material/application/use-cases/list-valid-upload-filetypes';
-import { MockEmbeddingProvider } from '@/contexts/material/infra/testing/mock-embedding-provider';
-import { MockSummarizer } from '@/contexts/material/infra/testing/mock-summarizer';
 
 export class MaterialController {
     constructor(

--- a/src/contexts/material/interface/web/material-routes.ts
+++ b/src/contexts/material/interface/web/material-routes.ts
@@ -41,13 +41,11 @@ materialRoutes.get(
 );
 
 function parseUploadRequest(req: Request): UserUpload {
-    console.log(req.body);
     const rawData = {
         projectId: req.body.projectId,
         title: req.body.title,
         mimeType: req.body.mimeType,
     };
-    console.log(rawData);
 
     const parseResult = UploadMaterialRequestSchema.safeParse(rawData);
     if (!parseResult.success) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,17 +41,17 @@ const server = app.listen(port, () => {
 });
 
 process.on('SIGTERM', () => {
-    console.log('SIGTERM received. Shutting down...');
+    logger.info('SIGTERM received. Shutting down...');
     server.close(() => {
-        console.log('Server closed.');
+        logger.info('Server closed.');
         process.exit(0);
     });
 });
 
 process.on('SIGINT', () => {
-    console.log('SIGINT received. Shutting down...');
+    logger.info('SIGINT received. Shutting down...');
     server.close(() => {
-        console.log('Server closed.');
+        logger.info('Server closed.');
         process.exit(0);
     });
 });


### PR DESCRIPTION
we're timing out the access token cookie with the same lifetime as it's validity, so there was no valid state to refresh - either access token was valid or it was not in the request so refresh failed.

removed access token from refresh requests - it's not strictly necessary and i think it's a better way than keeping it just to validate owner is consistent with refresh token.